### PR TITLE
maxdiff: show the number of bytes for an encrypted amxd

### DIFF
--- a/maxdiff/amxd_textconv.py
+++ b/maxdiff/amxd_textconv.py
@@ -26,6 +26,10 @@ def parse(path: str) -> str:
                 result += "<Patch is encrypted>\n"
             else:
                 result += parse_field(field, datasize, data)
+
+        if encrypted:
+            result += f"{file_obj.tell()} bytes"
+
     return result
 
 


### PR DESCRIPTION
This allows quickly checking if an encrypted device has changed apart from the cipher