### PR TITLE
Make maxdiff tests work again

### DIFF
--- a/maxdiff/tests/test_baselines/EncryptedTest.amxd.txt
+++ b/maxdiff/tests/test_baselines/EncryptedTest.amxd.txt
@@ -3,3 +3,4 @@ Audio Effect Device
 ----- Cipher -----
 ...8955be1abf021543
 <Patch is encrypted>
+73321 bytes


### PR DESCRIPTION
The issue was introduced in commit 5ee53f1 (maxdiff: show the number of bytes for an encrypted amxd)