### PR TITLE
Simplify ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: test
 on:
   push:
-  pull_request:
-  workflow_dispatch:
+  pull_request_target:
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,6 +13,3 @@ jobs:
       - run: |
          cd maxdiff
          python3 tests/test.py
-      - run: pip install --upgrade pip wheel
-      - run: pip install pytest
-      - run: pytest maxdiff/tests/test.py


### PR DESCRIPTION
Run on `push` and `pull_request_target`. The latter is added to enable running for PRs from forks, [see discussion here](https://github.com/Ableton/maxdevtools/pull/17#pullrequestreview-2031456311).

Also remove an extraneous test run.