### PR TITLE
Print dates as UTC to prevent conflicts based on time zone

### DIFF
--- a/maxdiff/frozen_device_printer.py
+++ b/maxdiff/frozen_device_printer.py
@@ -31,7 +31,7 @@ def parse_footer(data: bytes) -> list[str]:
         fields = get_fields(data[8 : 8 + size])
         if "fnam" in fields and "sz32" in fields and "mdat" in fields:
             dependencies.append(
-                f'{fields["fnam"]}: {fields["sz32"]} bytes, modified at {fields["mdat"].strftime("%Y/%m/%d %T")}'
+                f'{fields["fnam"]}: {fields["sz32"]} bytes, modified at {fields["mdat"].strftime("%Y/%m/%d %T")} UTC'
             )
         data = data[size:]
     return dependencies
@@ -80,5 +80,5 @@ def get_hfs_date(data: bytes) -> datetime.datetime:
     seconds_offset_from_unix = 2082844800  # Mac HFS+ is time since 1 Jan 1904 while Unix time is since 1 Jan 1970
     seconds_in_hfs_plus = int.from_bytes(data, byteorder="big")
     return datetime.datetime.fromtimestamp(
-        seconds_in_hfs_plus - seconds_offset_from_unix
+        seconds_in_hfs_plus - seconds_offset_from_unix, datetime.UTC
     )

--- a/maxdiff/tests/test_baselines/FrozenTest.amxd.txt
+++ b/maxdiff/tests/test_baselines/FrozenTest.amxd.txt
@@ -2,10 +2,10 @@ MIDI Effect Device
 -------------------
 Device is frozen
 ----- Contents -----
-Test.amxd: 21093 bytes, modified at 2024/05/27 09:52:44
-ParamAbstraction.maxpat: 1570 bytes, modified at 2024/05/24 15:59:36
-MyAbstraction.maxpat: 1625 bytes, modified at 2024/05/24 15:59:36
-AbstractionWithParameter.maxpat: 1569 bytes, modified at 2024/05/24 15:59:36
-hz-icon.svg: 484 bytes, modified at 2024/05/24 15:59:36
-beat-icon.svg: 533 bytes, modified at 2024/05/24 15:59:36
-fpic.png: 7094 bytes, modified at 2024/05/24 15:59:36
+Test.amxd: 21093 bytes, modified at 2024/05/27 07:52:44 UTC
+ParamAbstraction.maxpat: 1570 bytes, modified at 2024/05/24 13:59:36 UTC
+MyAbstraction.maxpat: 1625 bytes, modified at 2024/05/24 13:59:36 UTC
+AbstractionWithParameter.maxpat: 1569 bytes, modified at 2024/05/24 13:59:36 UTC
+hz-icon.svg: 484 bytes, modified at 2024/05/24 13:59:36 UTC
+beat-icon.svg: 533 bytes, modified at 2024/05/24 13:59:36 UTC
+fpic.png: 7094 bytes, modified at 2024/05/24 13:59:36 UTC


### PR DESCRIPTION
The maxdiff tests appeared to fail on CI because the dates were formatted based on the local machine's timezone. Now printed dates are always based on UTC, so the result is the same on every machine.