### PR TITLE
maxdiff: better handle malformed .maxpat files

### DIFF
--- a/maxdiff/maxpat_textconv.py
+++ b/maxdiff/maxpat_textconv.py
@@ -10,7 +10,20 @@ from print_unicode import print_unicode_string
 def parse(path: str) -> dict | str:
     """Parse a file and returns a textual representation of it."""
     with open(path, "r", encoding="utf-8") as file_obj:
-        patcher_dict = json.load(file_obj)
+        try:
+            patcher_dict = json.load(file_obj)
+        except Exception as e:
+            file_obj.seek(0)
+            file_string = file_obj.read()
+            if (
+                "=======" in file_string
+                or "<<<<<<<" in file_string
+                or ">>>>>>>" in file_string
+            ):
+                return "Patch file contains merge conflict markers. Please make sure to resolve merge conflicts."
+            else:
+                return f"Error parsing patch: {e}"
+
         return print_patcher(patcher_dict)
 
 

--- a/maxdiff/tests/test.py
+++ b/maxdiff/tests/test.py
@@ -13,74 +13,71 @@ class TestStringMethods(unittest.TestCase):
     def test_parse_device(self):
         self.maxDiff = None
 
-        expected_file_path = get_test_path_file("test_baselines/EncryptedTest.amxd.txt")
-        test_file_path = get_test_path_file("test_files/EncryptedTest.amxd")
+        expected_path, test_path = get_test_path_files("EncryptedTest.amxd")
 
-        with open(expected_file_path, mode="r") as expected_file:
+        with open(expected_path, mode="r") as expected_file:
             expected = expected_file.read()
-            actual = parse(test_file_path)
+            actual = parse(test_path)
             self.assertEqual(expected, actual)
 
     def test_parse_encrypted_device(self):
         self.maxDiff = None
 
-        expected_file_path = get_test_path_file("test_baselines/Test.amxd.txt")
-        test_file_path = get_test_path_file("test_files/Test.amxd")
+        expected_path, test_path = get_test_path_files("Test.amxd")
 
-        with open(expected_file_path, mode="r") as expected_file:
+        with open(expected_path, mode="r") as expected_file:
             expected = expected_file.read()
-            actual = parse(test_file_path)
+            actual = parse(test_path)
             self.assertEqual(expected, actual)
 
     def test_parse_frozen_device(self):
         self.maxDiff = None
 
-        expected_file_path = get_test_path_file("test_baselines/FrozenTest.amxd.txt")
-        test_file_path = get_test_path_file("test_files/FrozenTest.amxd")
+        expected_path, test_path = get_test_path_files("FrozenTest.amxd")
 
-        with open(expected_file_path, mode="r") as expected_file:
+        with open(expected_path, mode="r") as expected_file:
             expected = expected_file.read()
-            actual = parse(test_file_path)
+            actual = parse(test_path)
             self.assertEqual(expected, actual)
 
     def test_parse_maxpat(self):
         self.maxDiff = None
 
-        expected_file_path = get_test_path_file("test_baselines/Test.maxpat.txt")
-        test_file_path = get_test_path_file("test_files/Test.maxpat")
+        expected_path, test_path = get_test_path_files("Test.maxpat")
 
-        with open(expected_file_path, mode="r") as expected_file:
+        with open(expected_path, mode="r") as expected_file:
             expected = expected_file.read()
-            actual = parse(test_file_path)
+            actual = parse(test_path)
 
             self.assertEqual(expected, actual)
 
     def test_parse_als_zipped(self):
         self.maxDiff = None
 
-        expected_file_path = get_test_path_file(
-            "test_baselines/Test Project/Zipped.als.txt"
-        )
-        test_file_path = get_test_path_file("test_files/Test Project/Zipped.als")
+        expected_path, test_path = get_test_path_files("/Test Project/Zipped.als")
 
-        with open(expected_file_path, mode="r") as expected_file:
+        with open(expected_path, mode="r") as expected_file:
             expected = expected_file.read()
-            actual = parse(test_file_path)
+            actual = parse(test_path)
             self.assertEqual(expected, actual)
 
     def test_parse_als_unzipped(self):
         self.maxDiff = None
 
         # result of an unzipped set should be same as a zipped set
-        expected_file_path = get_test_path_file(
-            "test_baselines/Test Project/Test.als.txt"
-        )
-        test_file_path = get_test_path_file("test_files/Test Project/Test.als")
+        expected_path, test_path = get_test_path_files("/Test Project/Test.als")
 
-        with open(expected_file_path, mode="r") as expected_file:
+        with open(expected_path, mode="r") as expected_file:
             expected = expected_file.read()
-            actual = parse(test_file_path)
+            actual = parse(test_path)
             self.assertEqual(expected, actual)
+
+
+def get_test_path_files(file_name):
+    expected = get_test_path_file(f"test_baselines/{file_name}.txt")
+    test = get_test_path_file(f"test_files/{file_name}")
+
+    return (expected, test)
 
 
 def get_test_path_file(file_name):

--- a/maxdiff/tests/test.py
+++ b/maxdiff/tests/test.py
@@ -73,6 +73,28 @@ class TestStringMethods(unittest.TestCase):
             self.assertEqual(expected, actual)
 
 
+    def test_parse_malformed_maxpat(self):
+        self.maxDiff = None
+
+        expected_path, test_path = get_test_path_files("MalFormedJsonTest.maxpat")
+
+        with open(expected_path, mode="r") as expected_file:
+            expected = expected_file.read()
+            actual = parse(test_path)
+            self.assertEqual(expected, actual)
+
+
+    def test_parse_maxpat_with_merge_conficts(self):
+        self.maxDiff = None
+
+        expected_path, test_path = get_test_path_files("ConflictMarkerTest.maxpat")
+
+        with open(expected_path, mode="r") as expected_file:
+            expected = expected_file.read()
+            actual = parse(test_path)
+            self.assertEqual(expected, actual)
+
+
 def get_test_path_files(file_name):
     expected = get_test_path_file(f"test_baselines/{file_name}.txt")
     test = get_test_path_file(f"test_files/{file_name}")

--- a/maxdiff/tests/test.py
+++ b/maxdiff/tests/test.py
@@ -53,9 +53,6 @@ class TestStringMethods(unittest.TestCase):
             expected = expected_file.read()
             actual = parse(test_file_path)
 
-            # print ("expected: " + expected)
-            # print ("actual: " + actual)
-
             self.assertEqual(expected, actual)
 
     def test_parse_als_zipped(self):

--- a/maxdiff/tests/test_baselines/ConflictMarkerTest.maxpat.txt
+++ b/maxdiff/tests/test_baselines/ConflictMarkerTest.maxpat.txt
@@ -1,0 +1,1 @@
+Patch file contains merge conflict markers. Please make sure to resolve merge conflicts.

--- a/maxdiff/tests/test_baselines/MalFormedJsonTest.maxpat.txt
+++ b/maxdiff/tests/test_baselines/MalFormedJsonTest.maxpat.txt
@@ -1,0 +1,1 @@
+Error parsing patch: Extra data: line 1 column 17 (char 16)

--- a/maxdiff/tests/test_files/ConflictMarkerTest.maxpat
+++ b/maxdiff/tests/test_files/ConflictMarkerTest.maxpat
@@ -1,0 +1,76 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 5,
+			"revision" : 6,
+			"architecture" : "x64",
+			"modernui" : 1
+		}
+,
+		"classnamespace" : "box",
+		"rect" : [ 979.0, 778.0, 640.0, 480.0 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
+		"boxanimatetime" : 200,
+		"enablehscroll" : 1,
+		"enablevscroll" : 1,
+		"devicewidth" : 0.0,
+		"description" : "",
+		"digest" : "",
+		"tags" : "",
+		"style" : "",
+		"subpatcher_template" : "",
+		"assistshowspatchername" : 0,
+		"boxes" : [ 			{
+				"box" : 				{
+					"format" : 6,
+					"id" : "obj-4",
+					"maxclass" : "flonum",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 52.0, 119.0, 50.0, 22.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-2",
+<<<<<<< HEAD					
+					"maxclass" : "number",
+=======
+					"maxclass" : "flonum",
+>>>>>>>					
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 49.0, 64.0, 50.0, 22.0 ]
+				}
+
+			}
+ ],
+		"lines" : [  ],
+		"dependency_cache" : [  ],
+		"autosave" : 0
+	}
+
+}

--- a/maxdiff/tests/test_files/MalFormedJsonTest.maxpat
+++ b/maxdiff/tests/test_files/MalFormedJsonTest.maxpat
@@ -1,0 +1,82 @@
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 5,
+			"revision" : 5,
+			"architecture" : "x64",
+			"modernui" : 1
+		}
+,
+		"classnamespace" : "box",
+		"rect" : [ 312.0, 228.0, 221.0, 176.0 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
+		"boxanimatetime" : 200,
+		"enablehscroll" : 1,
+		"enablevscroll" : 1,
+		"devicewidth" : 0.0,
+		"description" : "",
+		"digest" : "",
+		"tags" : "",
+		"style" : "",
+		"subpatcher_template" : "",
+		"assistshowspatchername" : 0,
+		"boxes" : [ 			{
+				"box" : 				{
+					"comment" : "",
+					"id" : "obj-2",
+					"index" : 1,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 40.0, 60.0, 30.0, 30.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "",
+					"id" : "obj-1",
+					"index" : 1,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 40.0, 22.0, 30.0, 30.0 ]
+				}
+
+			}
+ ],
+		"lines" : [ 			{
+				"patchline" : 				{
+					"destination" : [ "obj-2", 0 ],
+					"source" : [ "obj-1", 0 ]
+				}
+
+			}
+ ],
+		"saved_attribute_attributes" : 		{
+			"default_plcolor" : 			{
+				"expression" : ""
+			}
+
+		}
+
+	}
+
+}

--- a/maxdiff/tests/test_rewrite_baselines.py
+++ b/maxdiff/tests/test_rewrite_baselines.py
@@ -17,6 +17,8 @@ def run():
     rewrite_file("Test.maxpat")
     rewrite_file("Test Project/Zipped.als")
     rewrite_file("Test Project/Test.als")
+    rewrite_file("MalFormedJsonTest.maxpat")
+    rewrite_file("ConflictMarkerTest.maxpat")
 
 
 def rewrite_file(name: str):


### PR DESCRIPTION
Instead of throwing an error, print proper feedback when a Max patch is malformed or has conflict markers.

fixes #24