### PR TITLE
Add and enforce black formatting rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,9 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-         cd maxdiff
-         python3 tests/test.py
+          pip install black
+      - run: |
+          black --check .
+      - run: |
+          cd maxdiff
+          python3 tests/test.py

--- a/maxdiff/CONTRIBUTING.md
+++ b/maxdiff/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Code is formatted using black:
 * Install [black](https://pypi.org/project/black/)
 * Run `black .` in the repo root
 
+Black formatting will be checked as a GitHub action for Pull Requests.
+
 ### Typing and using mypy in development
 
 This codebase uses the optional [typing](https://docs.python.org/3/library/typing.html) available in Python. This makes it so other tooling such as [mypy](https://mypy-lang.org/) can statically analyse your code for errors before you've even run a test. This synergy of types and tooling is useful in an automated context and for doing holistic evaluation, but also the types themselves can provide useful information to people reading and extending the codebase.
@@ -29,3 +31,5 @@ This codebase uses the optional [typing](https://docs.python.org/3/library/typin
 ### Testing
 
 Whenever making a change, we test that the previous functionality still works as before. For more info, see the [tests](tests/) folder.
+
+These tests will run as a GitHub action for Pull Requests.

--- a/maxdiff/als_textconv.py
+++ b/maxdiff/als_textconv.py
@@ -1,4 +1,5 @@
 """Module to convert an ALS file to a textual representation that can then be diffed."""
+
 import sys
 import gzip
 import argparse

--- a/maxdiff/amxd_textconv.py
+++ b/maxdiff/amxd_textconv.py
@@ -1,4 +1,5 @@
 """Module to convert an AMXD file to a textual representation that can then be diffed."""
+
 import sys
 import json
 import argparse

--- a/maxdiff/frozen_device_printer.py
+++ b/maxdiff/frozen_device_printer.py
@@ -50,7 +50,9 @@ def get_fields(data: bytes) -> dict[str, str | int | datetime.datetime]:
     return fields
 
 
-def parse_field_data(field_type: str, data: bytes) -> Optional[str | int | datetime.datetime]:
+def parse_field_data(
+    field_type: str, data: bytes
+) -> Optional[str | int | datetime.datetime]:
     """Parses the data of a field. Depending on the field type, returns its data as the correct type"""
     match field_type:
         case "type":
@@ -72,7 +74,7 @@ def parse_field_data(field_type: str, data: bytes) -> Optional[str | int | datet
 
 def remove_trailing_zeros(data: bytes) -> bytes:
     """Remove trailing zeros from a zero-padded byte representation of a string"""
-    return data.rstrip(b'\x00')
+    return data.rstrip(b"\x00")
 
 
 def get_hfs_date(data: bytes) -> datetime.datetime:

--- a/maxdiff/patch_printer.py
+++ b/maxdiff/patch_printer.py
@@ -272,9 +272,9 @@ def get_properties_to_print(
                 attributes, default, skip_properties
             )
             for new_key, new_value in attributes_to_print.items():
-                properties[
-                    new_key
-                ] = new_value  # this may overwrite existing value-based colors. This is ok, we want dynamic color values instead.
+                properties[new_key] = (
+                    new_value  # this may overwrite existing value-based colors. This is ok, we want dynamic color values instead.
+                )
             continue
 
         if key == "saved_object_attributes":

--- a/maxdiff/tests/test.py
+++ b/maxdiff/tests/test.py
@@ -72,7 +72,6 @@ class TestStringMethods(unittest.TestCase):
             actual = parse(test_path)
             self.assertEqual(expected, actual)
 
-
     def test_parse_malformed_maxpat(self):
         self.maxDiff = None
 
@@ -82,7 +81,6 @@ class TestStringMethods(unittest.TestCase):
             expected = expected_file.read()
             actual = parse(test_path)
             self.assertEqual(expected, actual)
-
 
     def test_parse_maxpat_with_merge_conficts(self):
         self.maxDiff = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 90


### PR DESCRIPTION
Formatting Python code was already listed as a preference in CONTRIBUTING.md but this PR enforces it by adding a check on push and pull request.

Also applies Ableton's formatting standard of a 90 characters line length.