### PR TITLE
Fix: correctly include last entry of frozen devices

### DIFF
--- a/maxdiff/frozen_device_printer.py
+++ b/maxdiff/frozen_device_printer.py
@@ -40,7 +40,7 @@ def parse_footer(data: bytes) -> list[str]:
 def get_fields(data: bytes) -> dict[str, str | int | datetime.datetime]:
     """Parses the data for a frozen dependency and returns a dict of its fields and their contents."""
     fields = {}
-    while len(data) > 12:
+    while len(data) >= 12:
         field_type = data[:4].decode("ascii")
         field_size = int.from_bytes(data[4:8], byteorder="big")
         field_data = data[8:field_size]

--- a/maxdiff/tests/test_baselines/FrozenTest.amxd.txt
+++ b/maxdiff/tests/test_baselines/FrozenTest.amxd.txt
@@ -9,3 +9,4 @@ AbstractionWithParameter.maxpat: 1569 bytes, modified at 2024/05/24 13:59:36 UTC
 hz-icon.svg: 484 bytes, modified at 2024/05/24 13:59:36 UTC
 beat-icon.svg: 533 bytes, modified at 2024/05/24 13:59:36 UTC
 fpic.png: 7094 bytes, modified at 2024/05/24 13:59:36 UTC
+collContent.txt: 8 bytes, modified at 2024/05/24 13:59:36 UTC


### PR DESCRIPTION
The frozen device summary missed the last file due to using `<` instead of `<=`