### PR TITLE
Tweak CI: remove on push for PRs and add names to CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: test
 on:
-  push:
   pull_request_target:
+  push:
+    branches:
+      - main    
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: |
+      - name: Install black
+        run: |
           pip install black
-      - run: |
+      - name: Run black (check only)
+        run: |
           black --check .
-      - run: |
+      - name: Run maxdiff tests
+        run: |
           cd maxdiff
           python3 tests/test.py


### PR DESCRIPTION
We originally included `push` to make sure PRs get tested when new commits are added or existing commits are changed. 

However, it appears that for an active PR, every push already causes a `synchronize` activity type for the `pull_request_target` event, which triggers the workflow. See the [`pull_request_target` documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

So the `push` event is no longer needed for PRs. Instead, we set it to trigger only for the case when something was pushed directly to the `main` branch as documented [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters).

Also adds names to CI steps like in [GitHub's examples](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#installing-dependencies).