### PR TITLE
fix: local styles rendering

### DIFF
--- a/maxdiff/patch_printer.py
+++ b/maxdiff/patch_printer.py
@@ -451,9 +451,17 @@ def get_project_string_block(project: dict):
     return f"project:\n\t{project_string}\n"
 
 
-def get_styles_string_block(styles: Any, indent: int) -> str:
+def get_styles_string_block(styles: Any) -> str:
     """Produce a string representing styles in a patcher."""
-    return "\n" + "\t" * indent + "styles: " + str(styles)
+    styles_string = ""
+
+    if len(styles) <= 0:
+        return styles_string
+
+    for style in styles:
+        styles_string += f"\t{style}\n"
+
+    return f"styles:\n{styles_string}\n"
 
 
 def get_object_parameter_string(parameter: dict) -> str:

--- a/maxdiff/tests/test.py
+++ b/maxdiff/tests/test.py
@@ -51,6 +51,16 @@ class TestStringMethods(unittest.TestCase):
 
             self.assertEqual(expected, actual)
 
+    def test_parse_maxpat_with_styles(self):
+        self.maxDiff = None
+        expected_path, test_path = get_test_path_files("PatcherWithLocalStyles.maxpat")
+
+        with open(expected_path, mode="r") as expected_file:
+            expected = expected_file.read()
+            actual = parse(test_path)
+
+            self.assertEqual(expected, actual)
+
     def test_parse_als_zipped(self):
         self.maxDiff = None
 

--- a/maxdiff/tests/test_baselines/PatcherWithLocalStyles.maxpat.txt
+++ b/maxdiff/tests/test_baselines/PatcherWithLocalStyles.maxpat.txt
@@ -1,0 +1,9 @@
+styles:
+	{'name': 'max6box', 'default': {'accentcolor': [0.8, 0.839216, 0.709804, 1.0], 'bgcolor': [1.0, 1.0, 1.0, 0.5], 'textcolor_inverse': [0.0, 0.0, 0.0, 1.0]}, 'parentstyle': '', 'multi': 0}
+	{'name': 'max6inlet', 'default': {'color': [0.423529, 0.372549, 0.27451, 1.0]}, 'parentstyle': '', 'multi': 0}
+
+
+----------- patcher -----------
+appversion: 9.0.0-x64-1 | rect: [1067, 692, 640, 480] | style: max6box | autosave: 0
+----------- objects -----------
+[coll] 

--- a/maxdiff/tests/test_files/PatcherWithLocalStyles.maxpat
+++ b/maxdiff/tests/test_files/PatcherWithLocalStyles.maxpat
@@ -1,0 +1,85 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 9,
+			"minor" : 0,
+			"revision" : 0,
+			"architecture" : "x64",
+			"modernui" : 1
+		}
+,
+		"classnamespace" : "box",
+		"rect" : [ 1067.0, 692.0, 640.0, 480.0 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
+		"boxanimatetime" : 200,
+		"enablehscroll" : 1,
+		"enablevscroll" : 1,
+		"devicewidth" : 0.0,
+		"description" : "",
+		"digest" : "",
+		"tags" : "",
+		"style" : "max6box",
+		"subpatcher_template" : "",
+		"assistshowspatchername" : 0,
+		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 4,
+					"outlettype" : [ "", "", "", "" ],
+					"patching_rect" : [ 29.0, 30.0, 50.5, 22.0 ],
+					"saved_object_attributes" : 					{
+						"embed" : 0,
+						"precision" : 6
+					}
+,
+					"text" : "coll"
+				}
+
+			}
+ ],
+		"lines" : [  ],
+		"dependency_cache" : [  ],
+		"autosave" : 0,
+		"styles" : [ 			{
+				"name" : "max6box",
+				"default" : 				{
+					"accentcolor" : [ 0.8, 0.839216, 0.709804, 1.0 ],
+					"bgcolor" : [ 1.0, 1.0, 1.0, 0.5 ],
+					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
+				}
+,
+				"parentstyle" : "",
+				"multi" : 0
+			}
+, 			{
+				"name" : "max6inlet",
+				"default" : 				{
+					"color" : [ 0.423529, 0.372549, 0.27451, 1.0 ]
+				}
+,
+				"parentstyle" : "",
+				"multi" : 0
+			}
+ ]
+	}
+
+}


### PR DESCRIPTION
I came across this error when trying to commit a patcher to version control that had a "styles" key with _local_ styles in the patcher. These are styles which only get added to the dictionary if the user has created local styles.

This was currently not caught by the test suite because none of the examples contained a local style and so the `get_style_string_block` function was never actually being called in those tests. When it was being called though, it was missing the indentation parameter and the script would fail.

This PR removes the indentation parameter which seems superfluous and modifies the function to behave exactly like `get_dependency_cache_string_block`.