### PR TITLE
maxdiff: update the FrozenTest baseline

### DIFF
--- a/maxdiff/tests/test_baselines/FrozenTest.amxd.txt
+++ b/maxdiff/tests/test_baselines/FrozenTest.amxd.txt
@@ -2,9 +2,9 @@ MIDI Effect Device
 -------------------
 Device is frozen
 ----- Contents -----
-Test.amxd: 21093 bytes, modified at 2024/05/27 07:52:44 UTC
+Test.amxd: 23958 bytes, modified at 2024/10/15 14:21:04 UTC
 ParamAbstraction.maxpat: 1570 bytes, modified at 2024/05/24 13:59:36 UTC
-MyAbstraction.maxpat: 1625 bytes, modified at 2024/05/24 13:59:36 UTC
+MyAbstraction.maxpat: 1625 bytes, modified at 2024/10/15 14:20:41 UTC
 AbstractionWithParameter.maxpat: 1569 bytes, modified at 2024/05/24 13:59:36 UTC
 hz-icon.svg: 484 bytes, modified at 2024/05/24 13:59:36 UTC
 beat-icon.svg: 533 bytes, modified at 2024/05/24 13:59:36 UTC


### PR DESCRIPTION
This was not caught by CI, so CI probably needs to be changed to trigger when creating a PR.