### PR TITLE
Use `pull_request` instead of `pull_request_target`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: test
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main    


### PR DESCRIPTION
This PR changes the GitHub Action trigger from `pull_request_target` to `pull_request`. 

`pull_request_target` seemed to be recommended for working with forks as laid out in [this article](https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/): 

> In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets. This makes common workflows like labeling or commenting on pull requests very difficult. In order to solve this, we’ve added a new `pull_request_target` event (...)

However this has had the effect that for PRs coming from a branch of this repository as opposed to a forked repository, tests ran on the base of the PR instead of taking the changes of the PR into account:
>  (...) we’ve added a new `pull_request_target` event, which behaves in an almost identical way to the `pull_request` event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request.

This explains why it was possible to merge PR #45 while the tests failed after the merge.

The effect this PR has on PRs coming from forks is not clear at this time but since that happens rarely we accept to address that once we run into actual issues in that scenario.
