### PR TITLE
maxdiff: Skip the orginid property that was introduced in Max 9

### DIFF
--- a/maxdiff/patch_printer.py
+++ b/maxdiff/patch_printer.py
@@ -78,6 +78,7 @@ def print_patcher_summary_recursive(
         "dependency_cache",  # treated separately
         "project",  # treated separately
         "styles",  # treated separately
+        "originid",  # invalid Max 9 property
     ]
 
     properties = get_properties_to_print(


### PR DESCRIPTION
This property will be removed in a next version of Max, but we still remove it from the diffs for now because this property changes every time you save the patch, making diffs hard to read.